### PR TITLE
Localizing macros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ bohm: bohm.a
 
 bohm.a: $(OBJS)
 
-$(OBJS): y.tab.h bohm.h define.h struct.h
+$(OBJS): y.tab.h bohm.h form.h struct.h
 
 lexer.c: y.tab.h
 

--- a/bohm.h
+++ b/bohm.h
@@ -5,6 +5,7 @@
 #include "struct.h"
 
 #include <stdbool.h>
+#include <time.h>
 
 extern bool error_detected;
 extern bool loading_mode;
@@ -13,6 +14,8 @@ extern bool seegarb;
 extern bool seenode;
 extern bool seetime;
 extern char *include_file;
+extern clock_t sys_garb_time;
+extern clock_t usr_garb_time;
 extern FORM *del_head;
 extern FORM *headfree;
 extern FORM *lastinputterm;

--- a/bohm.h
+++ b/bohm.h
@@ -1,7 +1,7 @@
 #ifndef _BOHM_H
 #define _BOHM_H
 
-#include "define.h"
+#include "form.h"
 #include "struct.h"
 
 #include <stdbool.h>

--- a/copy.c
+++ b/copy.c
@@ -28,23 +28,12 @@
 /*  - end_copy(): Eliminates hash table.			*/
 /****************************************************************/
 
-
-/****************************************************************/
-/* 1. Inclusion of header files.				*/
-/****************************************************************/
-
 #include "bohm.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 
-/****************************************************************/
-/* 2. Inclusion of declarations that are being imported.        */
-/****************************************************************/
-
-/****************************************************************/
-/* 3. Declaration of names strictly local to the module.	*/
-/****************************************************************/
+#define DIM_REL 256
 
 static COPY_FORM  *copy_relation[DIM_REL];
 static void       put_relation(),
@@ -53,10 +42,6 @@ static void       put_relation(),
 static FORM	  *is_in_relation(),
 		  *copy_aux();
 static int	  entry();
-
-/****************************************************************/
-/* 4. Definitions of functions to be exported.			*/
-/****************************************************************/
 
 /* The following function initialises the hash table, calls 	*/
 /* function copy_aux and eliminates the table.			*/
@@ -74,11 +59,6 @@ FORM
   end_copy();
   return risul;
 }
-
-/****************************************************************/
-/* 5. Definitions of functions strictly local to the module.	*/
-/****************************************************************/
-
 
 /* The following function duplicates the input graph and 	*/
 /* returns it as output.					*/

--- a/define.h
+++ b/define.h
@@ -1,32 +1,10 @@
 #ifndef _DEFINE_H
 #define _DEFINE_H
 
-/* constants concerning keywords */
-#define KEYWORDNUM			27
-#define FIRSTKEYWORD			400
-
-/* constants concerning the symbol table */
-#define DICTSIZE			211
-#define HASH1				4
-#define HASH2				0xf0000000
-#define HASH3				24
-
-/* constants concerning the machine stack */
-#ifndef         STACK_SIZE
-#define STACK_SIZE			(unsigned int)10000000
-#endif
-
-/* constants concerning scope analysis */
-#define NONESTING			-2
-
 /* constants concerning compile time error messages */
 #define ILLEGALCHAR			0
 #define NUMOVERFLOW			1
 #define UNBOUND_VARIABLE         	14
-
-/* constants concerning garbage */
-#define EXISTENT		3
-#define NOTEXISTENT		4
 
 /* constant concerning form names */
 #define ROOT                            0
@@ -76,18 +54,5 @@
 #define CDR1			       48
 #define CAR1			       49
 #define CONS1			       50
-
-/* constants concerning crash handling */
-#define COMPILERCRASH			2
-#define NOTENOUGHMEMORY			0
-
-/* constants concerning readback */
-#define PRINT_MAX	100
-
-/* constants concerning allocate form */
-#define FORM_NUM	1000
-
-/* constants concerning copy */
-#define DIM_REL		256
 
 #endif

--- a/define.h
+++ b/define.h
@@ -1,11 +1,6 @@
 #ifndef _DEFINE_H
 #define _DEFINE_H
 
-/* constants concerning compile time error messages */
-#define ILLEGALCHAR			0
-#define NUMOVERFLOW			1
-#define UNBOUND_VARIABLE         	14
-
 /* constant concerning form names */
 #define ROOT                            0
 #define T				-1

--- a/define.h
+++ b/define.h
@@ -1,11 +1,6 @@
 #ifndef _DEFINE_H
 #define _DEFINE_H
 
-/* constants concerning numbers */
-#define MAXINT				2147483647
-#define NUMBASE				10
-#define NUMOUTOFRANGE			-1
-
 /* constants concerning keywords */
 #define KEYWORDNUM			27
 #define FIRSTKEYWORD			400

--- a/define.h
+++ b/define.h
@@ -7,9 +7,6 @@
 #define DEF				1
 #define LOCAL				0
 
-/* constants concerning P I/O library procedures */
-#define LIBRARYPROCNUM			0
-
 /* constants concerning the symbol table */
 #define DICTSIZE			211
 #define HASH1				4

--- a/define.h
+++ b/define.h
@@ -1,29 +1,19 @@
 #ifndef _DEFINE_H
 #define _DEFINE_H
 
-/* constants concerning files */
-#define SUFFIXLENGTH			4
-#define NOMOREINPUT			1
-#define FROMCURRPOS			1
-
 /* constants concerning numbers */
 #define MAXINT				2147483647
 #define NUMBASE				10
 #define NUMOUTOFRANGE			-1
-#define DUMMYINTCONSTVALUE		1
 
 /* constants concerning keywords */
 #define KEYWORDNUM			27
 #define FIRSTKEYWORD			400
-#define LASTKEYWORD			426
 #define DEF				1
-#define SHARE				2
 #define LOCAL				0
 
 /* constants concerning P I/O library procedures */
 #define LIBRARYPROCNUM			0
-#define NOPAR				0
-#define NOPASSING			0
 
 /* constants concerning the symbol table */
 #define DICTSIZE			211
@@ -38,37 +28,15 @@
 
 /* constants concerning scope analysis */
 #define NONESTING			-2
-#define EXTERNALENVNESTINGDEPTH		-1
-#define GLOBALENVNESTINGDEPTH		0
 
 /* constants concerning compile time error messages */
 #define ILLEGALCHAR			0
 #define NUMOVERFLOW			1
-#define EXP_ID_AFTER_LET		2
-#define BAD_EXPR_IN_DECL                3
-#define EQUAL_EXPECTED_IN_DECL          4
-#define SINTAXERROR                     5
-#define CLOSE_BRACKET_EXPECTED          6
-#define EXP_ID_AFTER_LAMBDA		7
-#define EXP_ID_AFTER_LET_IN		8
-#define BAD_EXPR_IN_LET			9
-#define BAD_EXPR_IN_IN    		10
-#define BAD_EXPRESSION   		11
-#define EQUAL_EXPECTED_IN_LET_IN	12
-#define BAD_APPLICATION         	13
 #define UNBOUND_VARIABLE         	14
 
-/* constants concerning warning messages */
-#define VAR_ALREADY_DECLARED		0
-
 /* constants concerning garbage */
-#define OUT_OF_STACK		0
-#define IN_STACK		1
-#define DELETED			2
 #define EXISTENT		3
 #define NOTEXISTENT		4
-#define NOTINLIST		5
-
 
 /* constant concerning form names */
 #define ROOT                            0
@@ -77,7 +45,6 @@
 #define NIL			        -3
 #define INT			        -4
 #define ERASE		       	        5
-
 #define NOT			        6
 #define TRIANGLE                        9
 #define NOTEQ			       10
@@ -98,7 +65,6 @@
 #define LAMBDAUNB		       25
 #define UNS_FAN1		       27
 #define UNS_FAN2		       28
-
 #define APP                            29
 #define LAMBDA                         30
 #define FAN                            32
@@ -115,24 +81,15 @@
 #define LEQ			       43
 #define MEQ			       44
 #define CONS			       45
-
 #define IFELSE			       46
 #define TESTNIL1		       47
 #define CDR1			       48
 #define CAR1			       49
 #define CONS1			       50
 
-/* constants concerning run time errors */
-#define RUNTIMEERROR			2
-
 /* constants concerning crash handling */
 #define COMPILERCRASH			2
 #define NOTENOUGHMEMORY			0
-#define UNABLETOOPENFILE		1
-
-
-#define STAR          			1
-#define CIRCLE             		2
 
 /* constants concerning readback */
 #define PRINT_MAX	100
@@ -142,7 +99,5 @@
 
 /* constants concerning copy */
 #define DIM_REL		256
-
-#define NONAME 0
 
 #endif

--- a/define.h
+++ b/define.h
@@ -4,8 +4,6 @@
 /* constants concerning keywords */
 #define KEYWORDNUM			27
 #define FIRSTKEYWORD			400
-#define DEF				1
-#define LOCAL				0
 
 /* constants concerning the symbol table */
 #define DICTSIZE			211

--- a/dynall.c
+++ b/dynall.c
@@ -32,6 +32,10 @@
 /* 4. Definitions strictly local to the module.                 */
 /****************************************************************/
 
+/* constants concerning crash handling */
+#define COMPILERCRASH			2
+#define NOTENOUGHMEMORY			0
+
 /* The following function signals errors causing abort. */
 static void signal_crash(crash_type)
 	int crash_type; /* crash type */

--- a/error.c
+++ b/error.c
@@ -1,69 +1,11 @@
-/****************************************************************/
-/* This module supplies routines for error handling.		*/
-/* Upon error detection, the corresponding error message is	*/
-/* printed on the screen.                                	*/
-/* - signal_error(): it signals lexical, syntax and semantic	*/
-/*		     errors.					*/
-/****************************************************************/
-
-
-/****************************************************************/
-/* 1. Inclusion of header files.				*/
-/****************************************************************/
-
 #include "bohm.h"
 
 #include <stdio.h>
 
-/****************************************************************/
-/* 2. Inclusion of declarations that are being imported.        */
-/****************************************************************/
+bool error_detected;
 
-
-/****************************************************************/
-/* 3. Definitions of variables to be exported.			*/
-/****************************************************************/
-
-bool			error_detected;
-			      /* flag indicating whether an */
-			      /* error has been detected */
-
-/****************************************************************/
-/* 4. Definitions of variables strictly local to the module.	*/
-/****************************************************************/
-
-/* compile time error messages */
-static char *error_msgs[] = {
-  "lexical error: illegal character",
-  "lexical error: numerical constant overflow",
-  "syntax error: identifier expected after let",
-  "syntax error: bad expression in declaration",
-  "syntax error: = expected after identifier in declaration",
-  "syntax error",
-  "syntax error: missing closed bracket",
-  "syntax error: identifier expected after lambda",
-  "syntax error: identifier expected after let in expression",
-  "syntax error: bad expression in assignement of let_in expression",
-  "syntax error: bad expression in body of let_in expression",
-  "syntax error: bad expression",
-  "syntax error: = expected after identifier in let_in expression",
-  "syntax error: bad application",
-  "scoping error: undefined variable"
-};
-
-/****************************************************************/
-/* 5. Definitions of functions to be exported.			*/
-/****************************************************************/
-
- /* The following function signals lexical, syntax and semantic */
- /* errors. */
-void signal_error(error_msg_num)
-	int		error_msg_num;
-					/* error message number */
+void signal_error(const char *msg)
 {
 	error_detected = true;
-	fprintf(stderr,
-		"line %-5d\t--->\t%s\n",
-		lines,
-		error_msgs[error_msg_num]);
+	fprintf(stderr, "line %-5d\t--->\t%s\n", lines, msg);
 }

--- a/form.h
+++ b/form.h
@@ -1,7 +1,6 @@
-#ifndef _DEFINE_H
-#define _DEFINE_H
+#ifndef _FORM_H
+#define _FORM_H
 
-/* constant concerning form names */
 #define ROOT                            0
 #define T				-1
 #define F				-2

--- a/garbage.c
+++ b/garbage.c
@@ -31,8 +31,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
-#include <sys/types.h>
 #include <sys/times.h>
 
 /*************************************************************************/

--- a/garbage.c
+++ b/garbage.c
@@ -43,6 +43,10 @@
 /* 3. Declaration of names strictly local to the module.                 */
 /*************************************************************************/
 
+/* constants concerning garbage */
+#define EXISTENT		3
+#define NOTEXISTENT		4
+
 static void     garbage();
 
 /*************************************************************************/

--- a/graph.c
+++ b/graph.c
@@ -71,31 +71,17 @@
 /*  - remv(): it removes a variable from a list.                */
 /****************************************************************/
 
-
-
-/****************************************************************/
-/* 1. Inclusion of header files.				*/
-/****************************************************************/
-
 #include "bohm.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 
-/****************************************************************/
-/* 2. Inclusion of declarations that are being imported.        */
-/****************************************************************/
-
-/****************************************************************/
-/* 3. Definitions of variables to be exported.			*/
-/****************************************************************/
+/* constants concerning allocate form */
+#define FORM_NUM	1000
 
 unsigned num_nodes,max_nodes;
 
 unsigned length_list = 0;
-/****************************************************************/
-/* 4. Declaration of functions strictly local to the module.	*/
-/****************************************************************/
 
 static TERM             *makebox();
 static VARENTRY         *addbrackets(),
@@ -108,11 +94,6 @@ static void             allocate_var(),
                         closeglobalvars(),
 			intelligent_connect(),
 			inspect_connect();
-
-/****************************************************************/
-/* 5. Definitions of functions to be exported.			*/
-/****************************************************************/
-
 
  /* The following function creates the graph representation of */
  /* a variable */

--- a/lexer.l
+++ b/lexer.l
@@ -141,8 +141,6 @@ string                  [^\"]*\"
 			/* integer */
                         if (loading_mode == 1) ECHO; 
 			yylval.num_const = to_nat_s(yytext);
-			if (yylval.num_const == NUMOUTOFRANGE)
-				signal_error(NUMOVERFLOW);
 			return(NUMCONST);
 		   }
 
@@ -187,17 +185,19 @@ string                  [^\"]*\"
 
 %%
 
+#define MAXINT 2147483647
+
 /* The following function turns a given string of digits into a natural */
 /* and checks for presence of overflow. */
 static int to_nat_s(char *s)
 {
-	long n;
+	long long n;
 
 	for (n = 0; (n <= MAXINT) && (*s != '\0'); s++)
-		n = n * NUMBASE + (*s - '0');
+		n = 10 * n + (*s - '0');
 
 	if (n > MAXINT)
-		return(NUMOUTOFRANGE);
-	else
-		return((int)n);
+		signal_error(NUMOVERFLOW);
+
+	return n;
 }

--- a/lexer.l
+++ b/lexer.l
@@ -180,7 +180,7 @@ string                  [^\"]*\"
 {illegal_char}	{
 			/* detection of an illegal character */
                         if (loading_mode == 1) ECHO; 
-			signal_error(ILLEGALCHAR);
+			signal_error("lexical error: illegal character");
                 }
 
 %%
@@ -197,7 +197,7 @@ static int to_nat_s(char *s)
 		n = 10 * n + (*s - '0');
 
 	if (n > MAXINT)
-		signal_error(NUMOVERFLOW);
+		signal_error("lexical error: numerical constant overflow");
 
 	return n;
 }

--- a/parser.y
+++ b/parser.y
@@ -132,6 +132,8 @@ FORM                    *lastinputterm;
  /***************************************************************/
 
 %{
+#define UNBOUND_VARIABLE "scoping error: undefined variable"
+
 int                    app_nesting_depth;
 PATTERN                *pattmp;
 

--- a/parser.y
+++ b/parser.y
@@ -169,7 +169,6 @@ static bool defined();
 %token				LEQUAL         261
 %token				MEQUAL         262
 %token				NOTEQUAL       263
-%token				EOFKW          264
 %token				LETKW	       400
 %token				INKW           401
 %token                          INSPECTKW      402
@@ -191,7 +190,6 @@ static bool defined();
 %token				TAILKW         418
 %token				TESTNILKW      419
 %token				DEFKW          420
-%token				SHAREKW        421
 %token				NILKW          422
 %token				GARBAGEKW      423
 %token				OPTIONKW       424

--- a/parser.y
+++ b/parser.y
@@ -358,7 +358,7 @@ global_decl	:    DEFKW ID '='
 				  app_nesting_depth--;
 				  lastinputterm = closeterm(1,$5);
 				  $$ = lastinputterm;
-				  create_variable_binding($2,$$,DEF);
+				  create_variable_binding($2,$$);
 				}
 		;
 
@@ -488,7 +488,7 @@ expr0           : 	TRUEKW
 				{
 				  app_nesting_depth--;
 				  push_local_env();
-				  create_variable_binding($2,NULL,LOCAL);
+				  create_variable_binding($2, NULL);
 				}
 			expr
 				{
@@ -499,7 +499,7 @@ expr0           : 	TRUEKW
 		 |	LETRECKW ID '='
 				{
 				  push_local_env();
-				  create_variable_binding($2,NULL,LOCAL);
+				  create_variable_binding($2, NULL);
 				  app_nesting_depth++;
 				 }
 			expr
@@ -648,9 +648,7 @@ pattern         :       CONSKW '(' pattern ',' pattern ')'
                                   pattmp=(PATTERN *)malloc(sizeof(PATTERN));
                                   pattmp->term=
                                     buildvoidterm(app_nesting_depth);
-                                  create_variable_binding($1,
-                                                          NULL,
-                                                          LOCAL);
+                                  create_variable_binding($1, NULL);
                                   pattmp->var_list=
                                     makevarlist($1,pattmp->term);
                                   $$=pattmp;

--- a/readback.c
+++ b/readback.c
@@ -18,21 +18,12 @@
 #include <stdint.h>
 #include <stdio.h>
 
-/****************************************************************/
-/* Declaration of variables strictly local to the module.	*/
-/****************************************************************/
+#define PRINT_MAX 100
+
 static int left_to_print;
                   /* maximum number of characters yet to print */
 
-/****************************************************************/
-/* Declaration of functions strictly local to the module.	*/
-/****************************************************************/
 static void rdbk_1(), rdbk_list();
-
-
-/****************************************************************/
-/* Definitions of functions to be exported.			*/
-/****************************************************************/
 
  /* the following function prints on the standard output the */
  /* standard syntactical representation of the graphical term */

--- a/reducer.c
+++ b/reducer.c
@@ -37,16 +37,11 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
 #include <sys/times.h>
-#include <sys/types.h>
 
 /****************************************************************/
 /* 2. Inclusion of declarations that are being imported.        */
 /****************************************************************/
-
-extern clock_t usr_garb_time;
-extern clock_t sys_garb_time;
 
 /****************************************************************/
 /* 3. Definitions strictly local to the module.                 */

--- a/reducer.c
+++ b/reducer.c
@@ -63,6 +63,11 @@ static void    reduce_redex();
 static void    reduce_form();
 static FORM    *lo_redex();
 static int     auxnext;
+
+#ifndef STACK_SIZE
+#define STACK_SIZE 10000000
+#endif
+
 static FORM    *auxstack[STACK_SIZE];
 
 static FORM *pop()

--- a/struct.h
+++ b/struct.h
@@ -58,9 +58,6 @@ typedef struct binding_entry
 					/* pointer to the entry for the */
 					/* binding previously enforced */
 					/* in the same local environment */
-	  int			entry_type;
-					/* indicates DEF, SHARE or LOCAL */
-					/* type entry */
 	}		BINDINGENTRY;
 
 /* graphical form descriptor type */

--- a/symbol.c
+++ b/symbol.c
@@ -78,8 +78,7 @@
 /*		    in which it lies;				*/
 /* - hash_pjw(): it computes the hash function;			*/
 /* - allocate_local_env_entry(): it allocates a local		*/
-/*				 environment entry;		*/
-/* - allocate_binding_entry(): it allocates a binding entry.	*/
+/*				 environment entry.		*/
 /****************************************************************/
 
 
@@ -119,7 +118,6 @@ static int		curr_nesting_depth;
 
 static int              hash_pjw();
 static void             allocate_local_env_entry();
-static void             allocate_binding_entry();
 static void             move_bucket();
 static void             allocate_bucket();
 
@@ -294,7 +292,15 @@ void create_variable_binding(st,rootform)
 				/* term associated with the identifier */
 				/* (for global declarations only) */
 {
-	allocate_binding_entry(st,curr_local_env,rootform);
+	BINDINGENTRY	*b;
+
+	b = (BINDINGENTRY *)malloc_da(sizeof(BINDINGENTRY));
+	b->st_bucket = st;
+	b->root = rootform;
+	b->prev_id_binding = st->curr_binding;
+	st->curr_binding = b;
+	b->prev_local_binding = curr_local_env->last_local_binding;
+	curr_local_env->last_local_binding = b;
 }
 
 /****************************************************************/
@@ -364,30 +370,4 @@ void allocate_local_env_entry()
 	le->last_local_binding = NULL;
 	le->prev_local_env = curr_local_env;
 	curr_local_env = le;
-}
-
- /* The following function allocates a binding entry. */
-static 
-void allocate_binding_entry(st,le,rootform)
-	STBUCKET	*st;
-				/* pointer to the bucket for the */
-				/* identifier involved in the binding */
-	LOCALENVENTRY	*le;
-				/* pointer to the entry for the */
-				/* environment in which the binding */
-				/* is to be created */
-	FORM            *rootform;
-				/* pointer to the rootform of the */
-				/* term associated with the identifier */
-				/* (for global declarations only) */
-{
-	BINDINGENTRY	*b;
-
-	b = (BINDINGENTRY *)malloc_da(sizeof(BINDINGENTRY));
-	b->st_bucket = st;
-	b->root = rootform;
-	b->prev_id_binding = st->curr_binding;
-	st->curr_binding = b;
-	b->prev_local_binding = le->last_local_binding;
-	le->last_local_binding = b;
 }

--- a/symbol.c
+++ b/symbol.c
@@ -106,6 +106,19 @@
 /* 4. Definitions strictly local to the module.                 */
 /****************************************************************/
 
+/* constants concerning keywords */
+#define KEYWORDNUM			27
+#define FIRSTKEYWORD			400
+
+/* constants concerning the symbol table */
+#define DICTSIZE			211
+#define HASH1				4
+#define HASH2				0xf0000000
+#define HASH3				24
+
+/* constants concerning scope analysis */
+#define NONESTING			-2
+
 static LOCALENVENTRY *curr_local_env;
 			       /* pointer to the entry for the */
 			       /* current local environment */

--- a/symbol.c
+++ b/symbol.c
@@ -77,10 +77,6 @@
 /* - move_bucket(): it moves a bucket to the head of the list	*/
 /*		    in which it lies;				*/
 /* - hash_pjw(): it computes the hash function;			*/
-/* - push_external_env(): it pushes the entry for the external	*/
-/*			  environment onto the scope stack;	*/
-/* - push_global_env(): it pushes the entry for the global	*/
-/*			environment onto the scope stack;	*/
 /* - allocate_local_env_entry(): it allocates a local		*/
 /*				 environment entry;		*/
 /* - allocate_binding_entry(): it allocates a binding entry.	*/
@@ -118,24 +114,14 @@ static LOCALENVENTRY *curr_local_env;
 static STBUCKET *dictionary[DICTSIZE];
 			       /* pointers to bucket lists */
 
-static LOCALENVENTRY	*external_env;
-			       /* pointer to the entry for the */
-			       /* external environment */
-
 static int		curr_nesting_depth;
 		               /* current nesting depth */
 
-static void             push_external_env();
-static void             push_global_env();
 static int              hash_pjw();
 static void             allocate_local_env_entry();
 static void             allocate_binding_entry();
 static void             move_bucket();
 static void             allocate_bucket();
-
-/* I/O library procedure names */
-static char *		library_proc_names[] = {"empty"
-					       };
 
 /* keywords */
 static char *		keywords[] =
@@ -206,8 +192,8 @@ void init_symbol_table()
 	curr_local_env = NULL;
 	curr_nesting_depth = NONESTING;
 
-	push_external_env();
-	push_global_env();
+	push_local_env();
+	push_local_env();
 }
 
  /* The following function searches the symbol table for an identifier */
@@ -367,32 +353,6 @@ hash_pjw(id)
 			h = h ^ (g >> HASH3) ^ g;
 	}
 	return(h % DICTSIZE);
-}
-
- /* The following function pushes the entry for the external environment */
- /* onto the scope stack. */
-static
-void push_external_env()
-{
-	STBUCKET	*st;
-	int		i;
-
-	push_local_env(NULL);
-	external_env = curr_local_env;
-	for (i = 0; i < LIBRARYPROCNUM; i++)
-	{
-		search_bucket(&st,
-			      library_proc_names[i]);
-		allocate_binding_entry(st,external_env,NULL,DEF);
-	}
-}
-
- /* The following function pushes the entry for the global environment */
- /* onto the scope stack. */
-static
-void push_global_env()
-{
-	push_local_env();
 }
 
  /* The following function allocates a local environment entry. */

--- a/symbol.c
+++ b/symbol.c
@@ -284,7 +284,7 @@ void pop_local_env()
 }
 
  /* The following function creates entries for a variable binding */
-void create_variable_binding(st,rootform,type)
+void create_variable_binding(st,rootform)
 	STBUCKET	*st;
 				/* pointer to the bucket for the */
 				/* identifier which is to be bound */
@@ -293,11 +293,8 @@ void create_variable_binding(st,rootform,type)
 				/* pointer to the rootform of the */
 				/* term associated with the identifier */
 				/* (for global declarations only) */
-	int		type;
-				/* indicates DEF, SHARE or LOCAL */
-				/* type entry */
 {
-	allocate_binding_entry(st,curr_local_env,rootform,type);
+	allocate_binding_entry(st,curr_local_env,rootform);
 }
 
 /****************************************************************/
@@ -371,7 +368,7 @@ void allocate_local_env_entry()
 
  /* The following function allocates a binding entry. */
 static 
-void allocate_binding_entry(st,le,rootform,type)
+void allocate_binding_entry(st,le,rootform)
 	STBUCKET	*st;
 				/* pointer to the bucket for the */
 				/* identifier involved in the binding */
@@ -383,9 +380,6 @@ void allocate_binding_entry(st,le,rootform,type)
 				/* pointer to the rootform of the */
 				/* term associated with the identifier */
 				/* (for global declarations only) */
-	int		type;
-				/* indicates DEF, SHARE or LOCAL */
-				/* type entry */
 {
 	BINDINGENTRY	*b;
 
@@ -396,5 +390,4 @@ void allocate_binding_entry(st,le,rootform,type)
 	st->curr_binding = b;
 	b->prev_local_binding = le->last_local_binding;
 	le->last_local_binding = b;
-	b->entry_type = type;
 }


### PR DESCRIPTION
Task statement: localizes/expands macros in modules that use them exclusively, as planned in #4.

Further work:
* expands compound `typedef`s not to be confused with scalar types;
* completes function declarations in `bohm.h` including types and names of all arguments;
* factors out `<time.h>`-related source code into a new separate module `time.c`;
* identifies and factors out other independent components;
* passes building using `heirloom-lex` instead of Flex, in particular `yy_create_buffer`, `yypush_buffer_state`, and `yypop_buffer_state` to be avoided as non-standard;
* passes the `checkpatch.pl` script [provided](https://github.com/torvalds/linux/blob/46d832f5e2102cce455672c5a0b8cbe97e27fe42/scripts/checkpatch.pl) with the Linux kernel, thus aligning with [the Linux kernel coding style](https://github.com/torvalds/linux/blob/1dc4bbf0b268246f6202c761016735933b6f0b99/Documentation/process/coding-style.rst) (still awaiting the owner's approval prior to handling this task);
* implements a non-interactive mode in which input is read from a file (still blocked by #2);
* disables the interactive mode if standard input is not a terminal device (still blocked by #2).