### PR TITLE
Removing <time.h> from "bohm.h"

### DIFF
--- a/bohm.h
+++ b/bohm.h
@@ -77,6 +77,7 @@ extern void pop_local_env();
 extern void push_local_env();
 extern void rdbk();
 extern void reduce_term();
+extern void reset_garbage();
 extern void save();
 extern void search_bucket();
 extern void signal_error();

--- a/bohm.h
+++ b/bohm.h
@@ -5,7 +5,6 @@
 #include "struct.h"
 
 #include <stdbool.h>
-#include <time.h>
 
 extern bool error_detected;
 extern bool loading_mode;
@@ -14,15 +13,11 @@ extern bool seegarb;
 extern bool seenode;
 extern bool seetime;
 extern char *include_file;
-extern clock_t sys_garb_time;
-extern clock_t usr_garb_time;
 extern FORM *del_head;
 extern FORM *headfree;
 extern FORM *lastinputterm;
 extern int lines;
 extern int option;
-extern long unsigned cl_count;
-extern long unsigned er_count;
 extern unsigned limit;
 extern unsigned max_nodes;
 extern unsigned num_nodes;

--- a/bohm.h
+++ b/bohm.h
@@ -80,6 +80,7 @@ extern void reduce_term();
 extern void reset_garbage();
 extern void save();
 extern void search_bucket();
+extern void show_garb_stat();
 extern void signal_error();
 extern void user();
 

--- a/garbage.c
+++ b/garbage.c
@@ -416,7 +416,10 @@ FORM *erase;
 	}
 }
 
-
-
-
-
+void reset_garbage()
+{
+	er_count = 0;
+	cl_count = 0;
+	usr_garb_time = 0;
+	sys_garb_time = 0;
+}

--- a/garbage.c
+++ b/garbage.c
@@ -57,7 +57,6 @@ static void     garbage();
 /*************************************************************************/
 
 FORM *del_head=NULL;        	     /* head of erases list */
-struct tms partial_time, final_time;
 
 /*************************************************************************/
 /* 5. Definitions of functions to be exported.                           */
@@ -89,6 +88,7 @@ FORM *d;
 void clean()
 {
 	FORM *q;
+	struct tms partial_time, final_time;
 	if (seegarb)
 	  times(&partial_time);
 	cl_count++;

--- a/garbage.c
+++ b/garbage.c
@@ -423,3 +423,12 @@ void reset_garbage()
 	usr_garb_time = 0;
 	sys_garb_time = 0;
 }
+
+void show_garb_stat()
+{
+	printf("Total number of garbage calls      %lu\n", cl_count);
+	printf("Total number of garbage operations %lu\n", er_count);
+	printf("Garbage collection done in %.2f:usr %.2f:sys seconds\n",
+		(double)usr_garb_time / 60, (double)sys_garb_time / 60);
+	printf("*****************************************************\n");
+}

--- a/garbage.c
+++ b/garbage.c
@@ -45,17 +45,18 @@
 #define EXISTENT		3
 #define NOTEXISTENT		4
 
+static long unsigned er_count; /* counter for erasing operations */
+static long unsigned cl_count; /* counter for clean() calls */
+static clock_t usr_garb_time;
+static clock_t sys_garb_time;
+
 static void     garbage();
 
 /*************************************************************************/
 /* 4. Definitions of variables to be exported.                           */
 /*************************************************************************/
 
-long unsigned	er_count;	     /* counter for erasing operations */
-long unsigned   cl_count;	     /* counter for clean() calls.     */
 FORM *del_head=NULL;        	     /* head of erases list */
-clock_t      usr_garb_time;
-clock_t      sys_garb_time;
 struct tms partial_time, final_time;
 
 /*************************************************************************/

--- a/reducer.c
+++ b/reducer.c
@@ -119,8 +119,6 @@ void reduce_term(root)
      eq=0;
      redexes = 0;
      type_error = false;
-     er_count=0;
-     cl_count=0;
      max_index=0;
      if(seenode){
 	 printf("\n*****************************************************\n");
@@ -132,8 +130,7 @@ void reduce_term(root)
      sys_time = time.tms_stime;
      init_stack();
      f1 = lo_redex(root);
-     usr_garb_time = 0;
-     sys_garb_time = 0;
+     reset_garbage();
      while ((f1 != root) && (!type_error))
 	{
 	   if (f1->nport[0]==0) {

--- a/reducer.c
+++ b/reducer.c
@@ -168,12 +168,7 @@ void reduce_term(root)
 	    printf("*****************************************************\n");
 	}
 	if((option!=3)&&(seegarb))
-	  {
-	    printf("Total number of garbage calls      %lu\n",cl_count);
-	    printf("Total number of garbage operations %lu\n",er_count);
-	    printf("Garbage collection done in %.2f:usr %.2f:sys seconds\n",(double) usr_garb_time/60, (double)sys_garb_time/60);
-	    printf("*****************************************************\n");
-	  }
+		show_garb_stat();
 	if(seenode)
 	  {
 	    printf("Max. number of nodes seen up to this time %u\n",max_nodes);


### PR DESCRIPTION
Task statement: removes inclusion of `<time.h>` from `bohm.h`.

Rationale: instead of factoring out `<time.h>`-related source code to a new separate module `time.c` as  planned in #5, a more conservative change has been applied with the same effect as initially intended.

Further work:
* expands compound `typedef`s not to be confused with scalar types;
* completes function declarations in `bohm.h` including types and names of all arguments;
* identifies and factors out independent components;
* passes building using `heirloom-lex` instead of Flex, in particular `yy_create_buffer`, `yypush_buffer_state`, and `yypop_buffer_state` to be avoided as non-standard;
* passes the `checkpatch.pl` script [provided](https://github.com/torvalds/linux/blob/46d832f5e2102cce455672c5a0b8cbe97e27fe42/scripts/checkpatch.pl) with the Linux kernel, thus aligning with [the Linux kernel coding style](https://github.com/torvalds/linux/blob/1dc4bbf0b268246f6202c761016735933b6f0b99/Documentation/process/coding-style.rst) (still awaiting the owner's approval prior to handling this task);
* implements a non-interactive mode in which input is read from a file (still blocked by #2);
* disables the interactive mode if standard input is not a terminal device (still blocked by #2).